### PR TITLE
Base64 encode binary responses & include disk cache for saved responses

### DIFF
--- a/lib/PuppeteerHar.js
+++ b/lib/PuppeteerHar.js
@@ -46,10 +46,11 @@ class PuppeteerHar {
      * @param {{path: string}=} options
      * @return {Promise<void>}
      */
-    async start({ path, saveResponse, captureMimeTypes,loadingTimeout=5000 } = {}) {
+    async start({ path, saveResponse, captureMimeTypes, isBinaryMimeType, loadingTimeout=5000 } = {}) {
         this.inProgress = true;
         this.saveResponse = saveResponse || false;
         this.captureMimeTypes = captureMimeTypes || ['text/html', 'application/json'];
+        this.isBinaryMimeType = isBinaryMimeType || (m => /^(image|audio|video)\/.*|application\/octet-stream/.test(m))
         this.path = path;
         this.client = await this.page.target().createCDPSession();
         await this.client.send('Page.enable');
@@ -75,11 +76,19 @@ class PuppeteerHar {
                         'Network.getResponseBody', { requestId },
                     ).then((responseBody) => {
                         // Set the response so `chrome-har` can add it to the HAR
-                        response.body = new Buffer.from(
+                        let encoding = 'utf-8'
+                        const buffer = new Buffer.from(
                             responseBody.body,
                             responseBody.base64Encoded ? 'base64' : undefined,
-                        ).toString();
+                        )
+
+                        if (this.isBinaryMimeType(response.mimeType)) {
+                            encoding = 'base64'
+                            response.encoding = encoding
+                        }
+                        response.body = buffer.toString(encoding)
                     }, (reason) => {
+                        throw new Error(reason)
                         // Resources (i.e. response bodies) are flushed after page commits
                         // navigation and we are no longer able to retrieve them. In this
                         // case, fail soft so we still add the rest of the response to the

--- a/lib/PuppeteerHar.js
+++ b/lib/PuppeteerHar.js
@@ -121,7 +121,8 @@ class PuppeteerHar {
         await this.client.detach();
         const har = harFromMessages(
             this.page_events.concat(this.network_events),
-            {includeTextFromResponseBody: this.saveResponse}
+            {includeTextFromResponseBody: this.saveResponse,
+             includeResourcesFromDiskCache: this.saveResponse}
         );
         this.cleanUp();
         if (this.path) {


### PR DESCRIPTION
Hi, 

I've stumbled upon your fork, which seemed to be closest to my needs. Not sure whether you are accepting PR for this branch, but what would you think about those changes?

Especially base64 encoding seems useful, because without it, `puppeteer-har`s output might be invalid JSON - all JSON must be utf-8, binaries are forbidden.

Thanks